### PR TITLE
Parsing `Feature`, `boolean`, `Array` and `Object` arguments

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,10 +10,11 @@ var turf = require('turf'),
 
 function isFileArgument(type) {
     return type.type === 'NameExpression' &&
-        ['FeatureCollection', 'Point', 'GeoJSON', 'Geometry',
+        ['FeatureCollection', 'Feature', 'Point', 'GeoJSON', 'Geometry',
          'LineString', 'Polygon', 'MultiPolygon', 'MultiPoint']
          .indexOf(type.name) !== -1;
 }
+
 
 function parseArguments(def, argv) {
     if ((argv._.length - 1) !== def.params.length) {

--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,12 @@ function isFileArgument(type) {
          .indexOf(type.name) !== -1;
 }
 
+function isJsonArgument(type) {
+    return (type.type === 'NameExpression' &&
+                (type.name === 'Object' || type.name === 'boolean')) ||
+            (type.type === 'TypeApplication' &&
+                type.expression.name === 'Array');
+}
 
 function parseArguments(def, argv) {
     if ((argv._.length - 1) !== def.params.length) {
@@ -28,6 +34,8 @@ function parseArguments(def, argv) {
         var arg = argv._[i + 1];
         if (isFileArgument(param.type)) {
             args.push(JSON.parse(fs.readFileSync(arg)));
+        } else if (isJsonArgument(param.type)) {
+            args.push(JSON.parse(arg));
         } else {
             args.push(arg);
         }


### PR DESCRIPTION
I've found a few operations for which arguments are not currently handled correctly. This PR adds support for treating `Feature` arguments as a file and parsing `boolean`, `Array` and `Object` arguments.

Detail of operations tested:
### `simplify`
- expects a single GeoJSON `Feature` read from a file which is currently not interpreted as a file argument
- expects a `boolean` `highQuality` argument which is currently interpreted as a `String` hence passing `'true'` or `'false'` evaluate to `true`

Before changes:

```
$ node cli.js simplify poly.geojson 0.01 false

/usr/local/lib/node_modules/turf-cli/node_modules/turf/node_modules/turf-simplify/index.js:54
  if(feature.geometry.type === 'LineString') {
                     ^
TypeError: Cannot read property 'type' of undefined
    at module.exports (/usr/local/lib/node_modules/turf-cli/node_modules/turf/node_modules/turf-simplify/index.js:54:22)
    at /usr/local/lib/node_modules/turf-cli/cli.js:72:41
    at Object.<anonymous> (/usr/local/lib/node_modules/turf-cli/cli.js:73:3)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:902:3
```

After changes:

```
{
  "type": "Feature",
  "geometry": {
    "type": "Polygon",
    "coordinates": [
      [
        [
          -70.603637,
          -33.399918
        ],
        [
          -70.683975,
          -33.404504
        ],
        [
          -70.701141,
          -33.434306
        ],
        [
          -70.694274,
          -33.458369
        ],
        [
          -70.668869,
          -33.472117
        ],
        [
          -70.609817,
          -33.468107
        ],
        [
          -70.587158,
          -33.442901
        ],
        [
          -70.603637,
          -33.399918
        ]
      ]
    ]
  },
  "properties": {}
}
```
### `bboxPolygon`
- expects `bbox` as an `Array` which is currently interpreted as a `String`

Before changes:

```
$ node cli.js bboxPolygon '[-7.326378, 51.452846, -1.468778, 57.48444]'
{
    "type": "Feature",
    "geometry": {
        "type": "Polygon",
        "coordinates": [
        [
            [
            "[",
            "-"
            ],
            [
            "7",
            "-"
            ],
            [
            "7",
            "."
            ],
            [
            "[",
            "."
            ],
            [
            "[",
            "-"
            ]
        ]
        ]
    },
    "properties": {}
}
```

After changes:

```
$ node cli.js bboxPolygon '[-7.326378, 51.452846, -1.468778, 57.48444]'
{
    "type": "Feature",
    "geometry": {
        "type": "Polygon",
        "coordinates": [
        [
            [
            -7.326378,
            51.452846
            ],
            [
            -1.468778,
            51.452846
            ],
            [
            -1.468778,
            57.48444
            ],
            [
            -7.326378,
            57.48444
            ],
            [
            -7.326378,
            51.452846
            ]
        ]
        ]
    },
    "properties": {}
}
```
### `linestring`
- expects `coordinates` as an `Array` which is currently interpreted as a `String`
- expects `properties` as an `Object` which is currently interpreted as a `String`

Before changes:

```
node cli.js linestring '[-7.326378, 51.452846, -1.468778, 57.48444]' '{"name": "foo"}'

{
"type": "Feature",
"geometry": {
    "type": "LineString",
    "coordinates": "[-7.326378, 51.452846, -1.468778, 57.48444]"
},
"properties": "{\"name\": \"foo\"}"
}
```

After changes:

```
$ node cli.js linestring '[-7.326378, 51.452846, -1.468778, 57.48444]' '{"name": "foo"}'
{
    "type": "Feature",
    "geometry": {
        "type": "LineString",
        "coordinates": [
        -7.326378,
        51.452846,
        -1.468778,
        57.48444
        ]
    },
    "properties": {
        "name": "foo"
    }
}
```
