### PR TITLE
Accept stdin for JSON or GeoJSON args

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -48,10 +48,18 @@ function parseArguments(def, argv, stdin) {
     return args;
 }
 
+var usedStdin = false
 function  getJsonFromArg (arg, stdin) {
+    if (arg === '-' && usedStdin) {
+        console.log('STDIN ("-") can only be used once for JSON/GeoJSON input');
+        showParams(def.params);
+        throw new Error('stdin used for multiple file arguments');
+    }
+
     var raw
     if (arg === '-') {
         raw = stdin
+        usedStdin = true
     } else {
       try {
           // throws for a nonexistent file

--- a/cli.js
+++ b/cli.js
@@ -24,7 +24,7 @@ function isJsonArgument(type) {
 }
 
 function isBooleanArgument(type) {
-    return type.type === 'NameExpression' && type.name === 'boolean'
+    return type.type === 'NameExpression' && type.name === 'boolean';
 }
 
 function parseArguments(def, argv, stdin) {
@@ -51,18 +51,22 @@ function parseArguments(def, argv, stdin) {
 function  getJsonFromArg (arg, stdin) {
     var raw
     if (arg === '-') {
-        raw = JSON.parse(stdin)
+        raw = stdin
+    } else {
+      try {
+          // throws for a nonexistent file
+          raw = fs.readFileSync(arg)
+      } catch (e) {
+          // if `arg` doesn't point to a file, fall back to treating it as literal JSON
+          raw = arg
+      }
     }
 
     try {
-        // throws for a nonexistent file
-        raw = fs.readFileSync(arg)
+        return JSON.parse(raw);
     } catch (e) {
-        // if `arg` doesn't point to a file, fall back to treating it as literal JSON
-        raw = arg
+        console.log("Could not parse JSON: ", raw);
     }
-
-    return JSON.parse(raw)
 }
 
 function showParams(params) {

--- a/cli.js
+++ b/cli.js
@@ -18,9 +18,13 @@ function isGeoJsonArgument(type) {
 
 function isJsonArgument(type) {
     return (type.type === 'NameExpression' &&
-                (type.name === 'Object' || type.name === 'boolean')) ||
+                type.name === 'Object') ||
             (type.type === 'TypeApplication' &&
                 type.expression.name === 'Array');
+}
+
+function isBooleanArgument(type) {
+    return type.type === 'NameExpression' && type.name === 'boolean'
 }
 
 function parseArguments(def, argv, stdin) {
@@ -35,6 +39,8 @@ function parseArguments(def, argv, stdin) {
         var arg = argv._[i + 1];
         if (isGeoJsonArgument(param.type) || isJsonArgument(param.type)) {
             args.push(getJsonFromArg(arg, stdin));
+        } else if (isBooleanArgument(param.type)) {
+            args.push(JSON.parse(arg)); // parses 'false' to false
         } else {
             args.push(arg);
         }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "chalk": "^1.0.0",
+    "get-stdin": "^5.0.1",
     "minimist": "^1.1.1",
     "turf": "^2.0.2"
   },


### PR DESCRIPTION
Changes:
- Accepts a file for JSON (i.e. object, array) args, not just GeoJSON args (I don't see any reason to restrict passing a file to GeoJSON, but I can revert this part if it's not wanted)
- Accepts `-` wherever a (Geo)JSON arg is wanted, and uses `stdin` in that case
- Falls back to treating the arg as literal JSON if it doesn't work as a filename

Closes #6 
